### PR TITLE
8365579: ml64.exe is not the right assembler for Windows aarch64

### DIFF
--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -25,20 +25,46 @@
 
 name: 'Get MSYS2'
 description: 'Download MSYS2 and prepare a Windows host'
+inputs:
+  architecture:
+    description: 'Architecture'
+    required: true
 
 runs:
   using: composite
   steps:
-    - name: 'Install MSYS2'
+    - name: 'Install MSYS2 on x86.x64'
       id: msys2
       uses: msys2/setup-msys2@v2.28.0
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal
         release: false
+      if: ${{ inputs.architecture == 'x86.x64' }}
+
+    - name: 'Install MSYS2 on ARM64'
+      id: msys2-arm64
+      uses: msys2/setup-msys2@v2.28.0
+      with:
+        install: 'autoconf tar unzip zip make'
+        path-type: minimal
+        release: true
+        location: ${{ runner.tool_cache }}/msys2
+      if: ${{ inputs.architecture == 'ARM64' }}
 
       # We can't run bash until this is completed, so stick with pwsh
     - name: 'Set MSYS2 path'
       run: |
-        echo "${{ steps.msys2.outputs.msys2-location }}/usr/bin" >> $env:GITHUB_PATH
+        if ('${{ inputs.architecture }}' -eq 'ARM64') {
+          echo "${{ steps.msys2-arm64.outputs.msys2-location }}/usr/bin" >> $env:GITHUB_PATH
+        } else {
+          echo "${{ steps.msys2.outputs.msys2-location }}/usr/bin" >> $env:GITHUB_PATH
+        }
       shell: pwsh
+
+    # Remove the default config.site file provided by MSYS2 to ensure config.guess accurately detects the host system.  
+    - name: 'Remove default config.site'
+      run: |
+        echo "Removing default config.site"
+        rm -f /etc/config.site
+      shell: env /usr/bin/bash --login -eo pipefail {0}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,6 +31,9 @@ on:
       platform:
         required: true
         type: string
+      runs-on:
+        required: true
+        type: string
       extra-conf-options:
         required: false
         type: string
@@ -45,7 +48,7 @@ on:
       msvc-toolset-version:
         required: true
         type: string
-      msvc-toolset-architecture:
+      architecture:
         required: true
         type: string
       configure-arguments:
@@ -67,7 +70,7 @@ env:
 jobs:
   build-windows:
     name: build
-    runs-on: windows-2025
+    runs-on: ${{ inputs.runs-on }}
     defaults:
       run:
         shell: bash
@@ -87,12 +90,14 @@ jobs:
 
       - name: 'Get MSYS2'
         uses: ./.github/actions/get-msys2
+        with:
+          architecture: ${{ inputs.architecture }}
 
       - name: 'Get the BootJDK'
         id: bootjdk
         uses: ./.github/actions/get-bootjdk
         with:
-          platform: windows-x64
+          platform: ${{ inputs.platform }}
 
       - name: 'Get JTReg'
         id: jtreg
@@ -106,7 +111,12 @@ jobs:
         id: toolchain-check
         run: |
           set +e
-          '/c/Program Files/Microsoft Visual Studio/2022/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
+          if [ "${{ inputs.architecture }}" = "ARM64" ]; then
+            vcvars="vcvarsarm64.bat"
+          else
+            vcvars="vcvars64.bat"
+          fi
+          "/c/Program Files/Microsoft Visual Studio/2022/Enterprise/vc/auxiliary/build/${vcvars}" -vcvars_ver=${{ inputs.msvc-toolset-version }}
           if [ $? -eq 0 ]; then
             echo "Toolchain is already installed"
             echo "toolchain-installed=true" >> $GITHUB_OUTPUT
@@ -120,7 +130,7 @@ jobs:
           # Run Visual Studio Installer
           '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
             modify --quiet --installPath 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise' \
-            --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
+            --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.architecture }}
         if: steps.toolchain-check.outputs.toolchain-installed != 'true'
 
       - name: 'Configure'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -353,8 +353,9 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
+      runs-on: windows-2025
+      architecture: 'x86.x64'
       msvc-toolset-version: '14.44'
-      msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
@@ -366,10 +367,9 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
+      runs-on: windows-11-arm
+      architecture: 'ARM64'
       msvc-toolset-version: '14.44'
-      msvc-toolset-architecture: 'arm64'
-      make-target: 'hotspot'
-      extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
@@ -446,6 +446,22 @@ jobs:
     with:
       platform: windows-x64
       bootjdk-platform: windows-x64
+      architecture: 'x86.x64'
       runs-on: windows-2025
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
       debug-suffix: -debug
+
+  test-windows-aarch64:
+    name: windows-aarch64
+    needs:
+      - prepare
+      - build-windows-aarch64
+    uses: ./.github/workflows/test.yml
+    with:
+      platform: windows-aarch64
+      bootjdk-platform: windows-aarch64
+      architecture: 'ARM64'
+      runs-on: windows-11-arm
+      dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
+      debug-suffix: -debug
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ on:
       runs-on:
         required: true
         type: string
+      architecture:
+        required: false
+        type: string
       xcode-toolset-version:
         required: false
         type: string
@@ -132,6 +135,8 @@ jobs:
 
       - name: 'Get MSYS2'
         uses: ./.github/actions/get-msys2
+        with:
+          architecture: ${{ inputs.architecture }}
         if: runner.os == 'Windows'
 
       - name: 'Get the BootJDK'

--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -115,7 +115,11 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
     # Force preprocessor to run, just to make sure
     BASIC_ASFLAGS="-x assembler-with-cpp"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    BASIC_ASFLAGS="-nologo -c"
+    if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+      BASIC_ASFLAGS="-nologo"
+    else
+      BASIC_ASFLAGS="-nologo -c"
+    fi
   fi
   AC_SUBST(BASIC_ASFLAGS)
 

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -655,8 +655,11 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
   if test "x$TOOLCHAIN_TYPE" != xmicrosoft; then
     AS="$CC -c"
   else
-    if test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
-      # On 64 bit windows, the assembler is "ml64.exe"
+    if test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+      # On Windows aarch64, the assembler is "armasm64.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, armasm64)
+    elif test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
+      # On Windows x64, the assembler is "ml64.exe"
       UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
     else
       # otherwise, the assembler is "ml.exe"

--- a/make/common/native/CompileFile.gmk
+++ b/make/common/native/CompileFile.gmk
@@ -236,7 +236,7 @@ define CreateCompiledNativeFileBody
             # For assembler calls just create empty dependency lists
 	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
 	        $$($1_COMPILER) $$($1_FLAGS) \
-	        $(CC_OUT_OPTION)$$($1_OBJ) -Ta $$($1_SRC_FILE))) \
+	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE))) \
 	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1" ; \
 	    $(ECHO) > $$($1_DEPS_FILE) ; \
 	    $(ECHO) > $$($1_DEPS_TARGETS_FILE)

--- a/make/common/native/CompileFile.gmk
+++ b/make/common/native/CompileFile.gmk
@@ -155,6 +155,12 @@ define CreateCompiledNativeFileBody
         endif
         $1_FLAGS := $$($1_FLAGS) -DASSEMBLY_SRC_FILE='"$$($1_REL_ASM_SRC)"' \
             -include $(TOPDIR)/make/data/autoheaders/assemblyprefix.h
+      else ifeq ($(TOOLCHAIN_TYPE), microsoft)
+        ifeq ($(OPENJDK_TARGET_CPU), aarch64)
+          $1_NON_ASM_EXTENSION_FLAG :=
+        else
+          $1_NON_ASM_EXTENSION_FLAG := "-Ta"
+        endif
       endif
     else ifneq ($$(filter %.cpp %.cc %.mm, $$($1_FILENAME)), )
       # Compile as a C++ or Objective-C++ file
@@ -236,7 +242,7 @@ define CreateCompiledNativeFileBody
             # For assembler calls just create empty dependency lists
 	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
 	        $$($1_COMPILER) $$($1_FLAGS) \
-	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE))) \
+	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_NON_ASM_EXTENSION_FLAG) $$($1_SRC_FILE))) \
 	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1" ; \
 	    $(ECHO) > $$($1_DEPS_FILE) ; \
 	    $(ECHO) > $$($1_DEPS_TARGETS_FILE)

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -47,3 +47,7 @@ MACOS_X64_BOOT_JDK_SHA256=6bbfb1d01741cbe55ab90299cb91464b695de9a3ace85c15131aa2
 WINDOWS_X64_BOOT_JDK_EXT=zip
 WINDOWS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk24/1f9ff9062db4449d8ca828c504ffae90/36/GPL/openjdk-24_windows-x64_bin.zip
 WINDOWS_X64_BOOT_JDK_SHA256=11d1d9f6ac272d5361c8a0bef01894364081c7fb1a6914c2ad2fc312ae83d63b
+
+WINDOWS_AARCH64_BOOT_JDK_EXT=zip
+WINDOWS_AARCH64_BOOT_JDK_URL=https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B35-ea-beta/OpenJDK24U-jdk_aarch64_windows_hotspot_24_35-ea.zip
+WINDOWS_AARCH64_BOOT_JDK_SHA256=bf02f568a28ad8e615e9a05b69a02893a4cffa369dfe2ce916d5a7b75fcf384c

--- a/ms-patches/8365579-fix-wrong-aarch64-assembler.yml
+++ b/ms-patches/8365579-fix-wrong-aarch64-assembler.yml
@@ -1,0 +1,9 @@
+title: Use correct assembler for Windows aarch64
+- work_item: 2554879
+- jbs_bug: JDK-8365579
+- author: swesonga
+- owner: swesonga
+- contributors:
+- details:
+  - Backport of https://github.com/openjdk/jdk/pull/26791
+- release_note:

--- a/ms-patches/8365579-fix-wrong-aarch64-assembler.yml
+++ b/ms-patches/8365579-fix-wrong-aarch64-assembler.yml
@@ -1,9 +1,0 @@
-title: Use correct assembler for Windows aarch64
-- work_item: 2554879
-- jbs_bug: JDK-8365579
-- author: swesonga
-- owner: swesonga
-- contributors:
-- details:
-  - Backport of https://github.com/openjdk/jdk/pull/26791
-- release_note:


### PR DESCRIPTION
[ml64](https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170) is set as the assembler for the Windows platform but is specific to the x64 platform. The [armasm64](https://learn.microsoft.com/en-us/cpp/assembler/arm/arm-assembler-command-line-reference?view=msvc-170) assembler should be used for Windows AArch64.

The -c and -Ta options are only valid for ml64 and -Ta can be removed from CompileFile.gmk (assembling for x64 works without it).