### PR TITLE
Windows AArch64 safefetch implementation should not use structured exception handling

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -115,7 +115,11 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
     # Force preprocessor to run, just to make sure
     BASIC_ASFLAGS="-x assembler-with-cpp"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    BASIC_ASFLAGS="-nologo -c"
+    if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+      BASIC_ASFLAGS="-nologo"
+    else
+      BASIC_ASFLAGS="-nologo -c"
+    fi
   fi
   AC_SUBST(BASIC_ASFLAGS)
 

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -655,8 +655,11 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
   if test "x$TOOLCHAIN_TYPE" != xmicrosoft; then
     AS="$CC -c"
   else
-    if test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
-      # On 64 bit windows, the assembler is "ml64.exe"
+    if test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+      # On Windows aarch64, the assembler is "armasm64.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, armasm64)
+    elif test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
+      # On Windows x64, the assembler is "ml64.exe"
       UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
     else
       # otherwise, the assembler is "ml.exe"

--- a/make/common/native/CompileFile.gmk
+++ b/make/common/native/CompileFile.gmk
@@ -236,7 +236,7 @@ define CreateCompiledNativeFileBody
             # For assembler calls just create empty dependency lists
 	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
 	        $$($1_COMPILER) $$($1_FLAGS) \
-	        $(CC_OUT_OPTION)$$($1_OBJ) -Ta $$($1_SRC_FILE))) \
+	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE))) \
 	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1" ; \
 	    $(ECHO) > $$($1_DEPS_FILE) ; \
 	    $(ECHO) > $$($1_DEPS_TARGETS_FILE)

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2629,6 +2629,10 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     VM_Version::clear_apx_test_state();
     return Handle_Exception(exceptionInfo, VM_Version::cpuinfo_cont_addr_apx());
   }
+#elif defined(_M_ARM64)
+  if (handle_safefetch(exception_code, pc, (void*)exceptionInfo->ContextRecord)) {
+    return EXCEPTION_CONTINUE_EXECUTION;
+  }
 #endif
 
 #ifdef CAN_SHOW_REGISTERS_ON_ASSERT

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -150,6 +150,8 @@ public:
   // signal support
   static void* install_signal_handler(int sig, signal_handler_t handler);
   static void* user_handler();
+
+  static void context_set_pc(CONTEXT* uc, address pc);
 };
 
 #endif // OS_WINDOWS_OS_WINDOWS_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -115,6 +115,10 @@ intptr_t* os::fetch_bcp_from_context(const void* ucVoid) {
   return reinterpret_cast<intptr_t*>(uc->REG_BCP);
 }
 
+void os::win32::context_set_pc(CONTEXT* uc, address pc) {
+  uc->Pc = (intptr_t)pc;
+}
+
 bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
         struct _EXCEPTION_POINTERS* exceptionInfo, address pc, frame* fr) {
   PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;

--- a/src/hotspot/os_cpu/windows_aarch64/safefetch_windows_aarch64.S
+++ b/src/hotspot/os_cpu/windows_aarch64/safefetch_windows_aarch64.S
@@ -1,0 +1,65 @@
+;
+; Copyright (c) 2022 SAP SE. All rights reserved.
+; Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+;
+; This code is free software; you can redistribute it and/or modify it
+; under the terms of the GNU General Public License version 2 only, as
+; published by the Free Software Foundation.
+;
+; This code is distributed in the hope that it will be useful, but WITHOUT
+; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+; version 2 for more details (a copy is included in the LICENSE file that
+; accompanied this code).
+;
+; You should have received a copy of the GNU General Public License version
+; 2 along with this work; if not, write to the Free Software Foundation,
+; Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+;
+; Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+; or visit www.oracle.com if you need additional information or have any
+; questions.
+;
+
+    ; Support for int SafeFetch32(int* address, int defaultval);
+    ;
+    ;  x0 : address
+    ;  w1 : defaultval
+
+    ; needed to align function start to 4 byte
+    ALIGN  4
+    EXPORT _SafeFetch32_fault
+    EXPORT _SafeFetch32_continuation
+    EXPORT SafeFetch32_impl
+    AREA safefetch_text, CODE
+
+SafeFetch32_impl
+_SafeFetch32_fault
+    ldr w0, [x0]
+    ret
+
+_SafeFetch32_continuation
+    mov      x0, x1
+    ret
+
+    ; Support for intptr_t SafeFetchN(intptr_t* address, intptr_t defaultval);
+    ;
+    ;  x0 : address
+    ;  x1 : defaultval
+
+    ALIGN  4
+    EXPORT _SafeFetchN_fault
+    EXPORT _SafeFetchN_continuation
+    EXPORT SafeFetchN_impl
+
+SafeFetchN_impl
+_SafeFetchN_fault
+    ldr      x0, [x0]
+    ret
+
+_SafeFetchN_continuation
+    mov      x0, x1
+    ret
+
+    END

--- a/src/hotspot/share/runtime/safefetch.hpp
+++ b/src/hotspot/share/runtime/safefetch.hpp
@@ -31,7 +31,7 @@
 // Safefetch allows to load a value from a location that's not known
 // to be valid. If the load causes a fault, the error value is returned.
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_M_ARM64)
   // Windows uses Structured Exception Handling
   #include "safefetch_windows.hpp"
 #elif defined(ZERO) || defined (_AIX)


### PR DESCRIPTION
Windows AArch64 uses vectored exception handling but currently uses the same safefetch implementation as x64, which relies on structured exception handling. This change fixes safefetch on Windows AArch64 to not use SEH (the implemenation in safefetch.hpp). This change defines the static assembly language for the fetching code like the other aarch64 platforms have done and updates the exception handler to recognize exceptions from the safe fetch assembly instructions.