### PR TITLE
ShowRegistersOnAssertTest.java fails on Windows AArch64 due to test bug

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -115,7 +115,11 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
     # Force preprocessor to run, just to make sure
     BASIC_ASFLAGS="-x assembler-with-cpp"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    BASIC_ASFLAGS="-nologo -c"
+    if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+      BASIC_ASFLAGS="-nologo"
+    else
+      BASIC_ASFLAGS="-nologo -c"
+    fi
   fi
   AC_SUBST(BASIC_ASFLAGS)
 

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -655,8 +655,11 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
   if test "x$TOOLCHAIN_TYPE" != xmicrosoft; then
     AS="$CC -c"
   else
-    if test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
-      # On 64 bit windows, the assembler is "ml64.exe"
+    if test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+      # On Windows aarch64, the assembler is "armasm64.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, armasm64)
+    elif test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
+      # On Windows x64, the assembler is "ml64.exe"
       UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
     else
       # otherwise, the assembler is "ml.exe"

--- a/make/common/native/CompileFile.gmk
+++ b/make/common/native/CompileFile.gmk
@@ -236,7 +236,7 @@ define CreateCompiledNativeFileBody
             # For assembler calls just create empty dependency lists
 	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
 	        $$($1_COMPILER) $$($1_FLAGS) \
-	        $(CC_OUT_OPTION)$$($1_OBJ) -Ta $$($1_SRC_FILE))) \
+	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE))) \
 	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1" ; \
 	    $(ECHO) > $$($1_DEPS_FILE) ; \
 	    $(ECHO) > $$($1_DEPS_TARGETS_FILE)

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2629,6 +2629,10 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     VM_Version::clear_apx_test_state();
     return Handle_Exception(exceptionInfo, VM_Version::cpuinfo_cont_addr_apx());
   }
+#elif defined(_M_ARM64)
+  if (handle_safefetch(exception_code, pc, (void*)exceptionInfo->ContextRecord)) {
+    return EXCEPTION_CONTINUE_EXECUTION;
+  }
 #endif
 
 #ifdef CAN_SHOW_REGISTERS_ON_ASSERT

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2673,10 +2673,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         // Fatal red zone violation.
         overflow_state->disable_stack_red_zone();
         tty->print_raw_cr("An unrecoverable stack overflow has occurred.");
-#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
         report_error(t, exception_code, pc, exception_record,
                       exceptionInfo->ContextRecord);
-#endif
         return EXCEPTION_CONTINUE_SEARCH;
       }
     } else if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
@@ -2728,10 +2726,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
       }
 
       // Stack overflow or null pointer exception in native code.
-#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
       report_error(t, exception_code, pc, exception_record,
                    exceptionInfo->ContextRecord);
-#endif
       return EXCEPTION_CONTINUE_SEARCH;
     } // /EXCEPTION_ACCESS_VIOLATION
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2814,33 +2810,6 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 #endif
   return EXCEPTION_CONTINUE_SEARCH;
 }
-
-#if defined(USE_VECTORED_EXCEPTION_HANDLING)
-LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-#if defined(_M_ARM64)
-  address pc = (address) exceptionInfo->ContextRecord->Pc;
-#elif defined(_M_AMD64)
-  address pc = (address) exceptionInfo->ContextRecord->Rip;
-#else
-  #error unknown architecture
-#endif
-
-  // Fast path for code part of the code cache
-  if (CodeCache::low_bound() <= pc && pc < CodeCache::high_bound()) {
-    return topLevelExceptionFilter(exceptionInfo);
-  }
-
-  // If the exception occurred in the codeCache, pass control
-  // to our normal exception handler.
-  CodeBlob* cb = CodeCache::find_blob(pc);
-  if (cb != nullptr) {
-    return topLevelExceptionFilter(exceptionInfo);
-  }
-
-  return EXCEPTION_CONTINUE_SEARCH;
-}
-#endif
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
@@ -4470,7 +4439,7 @@ jint os::init_2(void) {
   // Setup Windows Exceptions
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
-  topLevelVectoredExceptionHandler = AddVectoredExceptionHandler(1, topLevelVectoredExceptionFilter);
+  topLevelVectoredExceptionHandler = AddVectoredExceptionHandler(1, topLevelExceptionFilter);
   previousUnhandledExceptionFilter = SetUnhandledExceptionFilter(topLevelUnhandledExceptionFilter);
 #endif
 

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -150,6 +150,8 @@ public:
   // signal support
   static void* install_signal_handler(int sig, signal_handler_t handler);
   static void* user_handler();
+
+  static void context_set_pc(CONTEXT* uc, address pc);
 };
 
 #endif // OS_WINDOWS_OS_WINDOWS_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -115,6 +115,10 @@ intptr_t* os::fetch_bcp_from_context(const void* ucVoid) {
   return reinterpret_cast<intptr_t*>(uc->REG_BCP);
 }
 
+void os::win32::context_set_pc(CONTEXT* uc, address pc) {
+  uc->Pc = (intptr_t)pc;
+}
+
 bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
         struct _EXCEPTION_POINTERS* exceptionInfo, address pc, frame* fr) {
   PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;

--- a/src/hotspot/os_cpu/windows_aarch64/safefetch_windows_aarch64.S
+++ b/src/hotspot/os_cpu/windows_aarch64/safefetch_windows_aarch64.S
@@ -1,0 +1,65 @@
+;
+; Copyright (c) 2022 SAP SE. All rights reserved.
+; Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+;
+; This code is free software; you can redistribute it and/or modify it
+; under the terms of the GNU General Public License version 2 only, as
+; published by the Free Software Foundation.
+;
+; This code is distributed in the hope that it will be useful, but WITHOUT
+; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+; version 2 for more details (a copy is included in the LICENSE file that
+; accompanied this code).
+;
+; You should have received a copy of the GNU General Public License version
+; 2 along with this work; if not, write to the Free Software Foundation,
+; Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+;
+; Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+; or visit www.oracle.com if you need additional information or have any
+; questions.
+;
+
+    ; Support for int SafeFetch32(int* address, int defaultval);
+    ;
+    ;  x0 : address
+    ;  w1 : defaultval
+
+    ; needed to align function start to 4 byte
+    ALIGN  4
+    EXPORT _SafeFetch32_fault
+    EXPORT _SafeFetch32_continuation
+    EXPORT SafeFetch32_impl
+    AREA safefetch_text, CODE
+
+SafeFetch32_impl
+_SafeFetch32_fault
+    ldr w0, [x0]
+    ret
+
+_SafeFetch32_continuation
+    mov      x0, x1
+    ret
+
+    ; Support for intptr_t SafeFetchN(intptr_t* address, intptr_t defaultval);
+    ;
+    ;  x0 : address
+    ;  x1 : defaultval
+
+    ALIGN  4
+    EXPORT _SafeFetchN_fault
+    EXPORT _SafeFetchN_continuation
+    EXPORT SafeFetchN_impl
+
+SafeFetchN_impl
+_SafeFetchN_fault
+    ldr      x0, [x0]
+    ret
+
+_SafeFetchN_continuation
+    mov      x0, x1
+    ret
+
+    END

--- a/src/hotspot/share/runtime/safefetch.hpp
+++ b/src/hotspot/share/runtime/safefetch.hpp
@@ -31,7 +31,7 @@
 // Safefetch allows to load a value from a location that's not known
 // to be valid. If the load causes a fault, the error value is returned.
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_M_ARM64)
   // Windows uses Structured Exception Handling
   #include "safefetch_windows.hpp"
 #elif defined(ZERO) || defined (_AIX)

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -76,7 +76,15 @@ public class ShowRegistersOnAssertTest {
             } else if (Platform.isX86()) {
                 pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("EAX=.*")};
             } else if (Platform.isAArch64()) {
-                pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("R0=.*")};
+                if (Platform.isLinux()) {
+                    pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("R0=.*")};
+                } else if (Platform.isWindows()) {
+                    pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("X0 =.*")};
+                } else if (Platform.isOSX()) {
+                    pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("x0=.*")};
+                } else {
+                    pattern = new Pattern[] { Pattern.compile("Registers:")};
+                }
             } else if (Platform.isS390x()) {
                 pattern = new Pattern[] { Pattern.compile("General Purpose Registers:"),
                                           Pattern.compile("^-{26}$"),

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -80,10 +80,6 @@ public class ShowRegistersOnAssertTest {
                     pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("R0=.*")};
                 } else if (Platform.isWindows()) {
                     pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("X0 =.*")};
-                } else if (Platform.isOSX()) {
-                    pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("x0=.*")};
-                } else {
-                    pattern = new Pattern[] { Pattern.compile("Registers:")};
                 }
             } else if (Platform.isS390x()) {
                 pattern = new Pattern[] { Pattern.compile("General Purpose Registers:"),


### PR DESCRIPTION
This test verifies that registers are printed in the error log when VMError::controlled_crash() is called. However, it searches for the pattern "R0=" (which is valid on Linux AArch64) instead of "X0=" on Windows AArch64.

See the Windows AArch64 [os::print_context](https://github.com/openjdk/jdk/blob/999761d0f6d37c9cd6ec482620800b694c5fb9ad/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp#L184-L186) implementation for the correct format.