### PR TITLE
Create microsoft-patch-index.yml for patch tracking

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -1,0 +1,36 @@
+# Microsoft patches applied to the Microsoft Build of OpenJDK
+#
+# This index file is ouur explicit record of patches we are maintaining for our build of
+# the OpenJDK until they are (a) merged upstream, (b) abandoned, or (c) no longer
+# required by Microsoft's internal processes (we use Azure DevOps for our builds and
+# test, for instance).
+#
+# For each patch branch, there  will be a file in the ms-patches/ folder that has the
+# name of the branch in its file name (for example, this file follows that pattern).
+# The file is the source data for the README file we generate in the release branch, and
+# contains such information as Microsoft dev responsible for the patch, the original
+# author(s), associated JEP- or JBS- issue, and a summary of the patch's purpose.
+
+
+## Active Patches
+# Patches that we are applying to each release.
+active-patches:
+# - ms-patches/microsoft-patch-index // this patch branch is required for all releases
+  - ms-patches/aotergo
+  - ms-patches/gettemppath2
+  - ms-patches/8357445-g1-time-based-heap-uncommit
+  - ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm
+  - ms-patches/remove_undocumentedAPI
+
+
+## Upstreamed Patches
+# Patches that we are no longer applying to our releases, as they
+# have been upstreamed and are part of the official OpenJDK sources.
+#
+# upstreamed-patches: 
+
+
+# Patches that we are no longer applying to our releases as they have
+# been abandoned for one reason or another.
+#
+# abandoned-patches:

--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -21,6 +21,7 @@ active-patches:
   - ms-patches/8357445-g1-time-based-heap-uncommit
   - ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm
   - ms-patches/remove_undocumentedAPI
+  - ms-patches/win-aarch64-fixes
 
 
 ## Upstreamed Patches


### PR DESCRIPTION
This file serves as an index for Microsoft patches applied to the Microsoft Build of OpenJDK, detailing active, upstreamed, and abandoned patches.