### PR TITLE
Perform error reporting for uncaught native exceptions

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2802,17 +2802,18 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     }
   }
 
-#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
-  if (exception_code != EXCEPTION_BREAKPOINT) {
-    report_error(t, exception_code, pc, exception_record,
-                 exceptionInfo->ContextRecord);
-  }
-#else
-  if (exception_code != EXCEPTION_BREAKPOINT && exception_code != DBG_PRINTEXCEPTION_C) {
-    report_error(t, exception_code, pc, exception_record,
-                 exceptionInfo->ContextRecord);
-  }
+  bool should_report_error = (exception_code != EXCEPTION_BREAKPOINT);
+
+#if defined(_M_ARM64)
+  should_report_error = should_report_error &&
+                        (exception_code != DBG_PRINTEXCEPTION_C);
 #endif
+
+  if (should_report_error) {
+    report_error(t, exception_code, pc, exception_record,
+                 exceptionInfo->ContextRecord);
+  }
+
   return EXCEPTION_CONTINUE_SEARCH;
 }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2802,11 +2802,17 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     }
   }
 
+#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
   if (exception_code != EXCEPTION_BREAKPOINT) {
     report_error(t, exception_code, pc, exception_record,
                  exceptionInfo->ContextRecord);
   }
-
+#else
+  if (exception_code != EXCEPTION_BREAKPOINT && exception_code != DBG_PRINTEXCEPTION_C) {
+    report_error(t, exception_code, pc, exception_record,
+                 exceptionInfo->ContextRecord);
+  }
+#endif
   return EXCEPTION_CONTINUE_SEARCH;
 }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2802,12 +2802,11 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     }
   }
 
-#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
   if (exception_code != EXCEPTION_BREAKPOINT) {
     report_error(t, exception_code, pc, exception_record,
                  exceptionInfo->ContextRecord);
   }
-#endif
+
   return EXCEPTION_CONTINUE_SEARCH;
 }
 


### PR DESCRIPTION
The topLevelExceptionFilter currently reports uncaught exceptions when vectored exception handling is not used (i.e. on Windows x64 only). This change fixes it to report these exceptions when using vectored exception handling (which is the case on Windows AArch64). Exceptions with exception code DBG_PRINTEXCEPTION_C are thrown in the course of normal execution on Windows AArch64 so this change does not perform error reporting for these specific exceptions (in addition to EXCEPTION_BREAKPOINT, which is currently exempt from error reporting). UncaughtNativeExceptionTest now passes with this change (see https://github.com/microsoft/openjdk-jdk25u/actions/runs/17405264127/job/49415283318#step:10:610 for the passing log entry).