### PR TITLE
Add missing ms-patches .yml file

### DIFF
--- a/ms-patches/win-aarch64-fixes.yml
+++ b/ms-patches/win-aarch64-fixes.yml
@@ -1,0 +1,10 @@
+title: Windows AArch64 bug fixes
+- work_item: 2547147
+- jbs_bug:
+- author: kthatipally, macarte, swesonga
+- owner: kthatipally, macarte, swesonga
+- contributors: kthatipally, macarte, swesonga
+- details:
+- release_note:
+  - Fixes serviceability bugs that result in thread contexts being unavailable in hsdb on Windows AArch64
+  - Fixes core dump creation failure on Windows AArch64


### PR DESCRIPTION
I missed the fact that we renamed the branch from win-aarch64-fixes to ms-patches/win-aarch64-fixes but hadn't created the .yml file.