### PR TITLE
Do not report errors unless FAILED returns true for the exception code

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2806,7 +2806,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
 #if defined(_M_ARM64)
   should_report_error = should_report_error &&
-                        (exception_code != DBG_PRINTEXCEPTION_C);
+                        FAILED(exception_code);
 #endif
 
   if (should_report_error) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2806,7 +2806,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
 #if defined(_M_ARM64)
   should_report_error = should_report_error &&
-                        FAILED(exception_code);
+                        FAILED(exception_code) &&
+                        (exception_code != EXCEPTION_UNCAUGHT_CXX_EXCEPTION);
 #endif
 
   if (should_report_error) {

--- a/test/hotspot/jtreg/runtime/ErrorHandling/UncaughtNativeExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/UncaughtNativeExceptionTest.java
@@ -64,7 +64,7 @@ public class UncaughtNativeExceptionTest {
         assertTrue(Files.exists(hsErrPath));
 
         Pattern[] positivePatterns = {
-            Pattern.compile(".*Internal Error \\(0xcafebabe\\).*")
+            Pattern.compile(".*Internal Error \\(0xdeadbeef\\).*")
         };
         HsErrFileUtils.checkHsErrFileContent(hsErrFile, positivePatterns, null, true /* check end marker */, false /* verbose */);
     }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/UncaughtNativeExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/UncaughtNativeExceptionTest.java
@@ -64,7 +64,7 @@ public class UncaughtNativeExceptionTest {
         assertTrue(Files.exists(hsErrPath));
 
         Pattern[] positivePatterns = {
-            Pattern.compile(".*Internal Error \\(0x2a\\).*")
+            Pattern.compile(".*Internal Error \\(0xcafebabe\\).*")
         };
         HsErrFileUtils.checkHsErrFileContent(hsErrFile, positivePatterns, null, true /* check end marker */, false /* verbose */);
     }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/libNativeException.c
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/libNativeException.c
@@ -25,7 +25,8 @@
 
 #include <Windows.h>
 
-const DWORD EX_CODE = 42;
+// Use an exception code that causes the FAILED() macro to return true.
+const DWORD EX_CODE = 0xcafebabe;
 
 JNIEXPORT void JNICALL Java_UncaughtNativeExceptionTest_00024Crasher_throwException(JNIEnv* env, jclass cls) {
   RaiseException(EX_CODE, EXCEPTION_NONCONTINUABLE, 0, NULL);

--- a/test/hotspot/jtreg/runtime/ErrorHandling/libNativeException.c
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/libNativeException.c
@@ -26,7 +26,7 @@
 #include <Windows.h>
 
 // Use an exception code that causes the FAILED() macro to return true.
-const DWORD EX_CODE = 0xcafebabe;
+const DWORD EX_CODE = 0xdeadbeef;
 
 JNIEXPORT void JNICALL Java_UncaughtNativeExceptionTest_00024Crasher_throwException(JNIEnv* env, jclass cls) {
   RaiseException(EX_CODE, EXCEPTION_NONCONTINUABLE, 0, NULL);


### PR DESCRIPTION
Exceptions not directly related to the JVM can be raised in the course of execution on Windows. An example of such a scenario: an exception with code DBG_PRINTEXCEPTION_C is raised when OutputDebugString is called (which in this case allows an app to intercept its own trace output, for example). This change prevents the JVM from creating a core dump and terminating if the exception code is not a failure code as determined by the Windows FAILED macro. For more on error codes, see https://learn.microsoft.com/en-us/windows/win32/learnwin32/error-codes-in-com