### PR TITLE
Do not modify r18_tls when restoring registers on Windows AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -310,7 +310,18 @@ static void restore_live_registers(StubAssembler* sasm, bool restore_fpu_registe
     __ add(sp, sp, 32 * wordSize);
   }
 
+#ifdef _WINDOWS
+  /*
+  Do not modify r18_tls when restoring registers on Windows as it is used to
+  store the pointer to the current thread's TEB (where TLS variables are stored).
+  See r18_tls comment in register_aarch64.hpp.
+  */
+  __ pop(RegSet::range(r0, r17), sp);
+  __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
+  __ pop(RegSet::range(r20, r29), sp);
+#else
   __ pop(RegSet::range(r0, r29), sp);
+#endif
 }
 
 static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_fpu_registers = true)  {
@@ -323,8 +334,20 @@ static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_f
     __ add(sp, sp, 32 * wordSize);
   }
 
+#ifdef _WINDOWS
+  /*
+  Do not modify r18_tls when restoring registers on Windows as it is used to
+  store the pointer to the current thread's TEB (where TLS variables are stored).
+  See r18_tls comment in register_aarch64.hpp.
+  */
+  __ ldp(zr, r1, Address(__ post(sp, 2 * wordSize)));
+  __ pop(RegSet::range(r2, r17), sp);
+  __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
+  __ pop(RegSet::range(r20, r29), sp);
+#else
   __ ldp(zr, r1, Address(__ post(sp, 16)));
   __ pop(RegSet::range(r2, r29), sp);
+#endif
 }
 
 

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -310,11 +310,11 @@ static void restore_live_registers(StubAssembler* sasm, bool restore_fpu_registe
     __ add(sp, sp, 32 * wordSize);
   }
 
-#ifdef _WINDOWS
+#ifdef R18_RESERVED
   /*
-  Do not modify r18_tls when restoring registers on Windows as it is used to
-  store the pointer to the current thread's TEB (where TLS variables are stored).
-  See r18_tls comment in register_aarch64.hpp.
+  Do not modify r18_tls when restoring registers if it is a reserved register. On Windows,
+  for example, r18_tls is used to store the pointer to the current thread's TEB (where TLS
+  variables are stored). Therefore, modifying r18_tls would corrupt the TEB pointer.
   */
   __ pop(RegSet::range(r0, r17), sp);
   __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
@@ -334,11 +334,11 @@ static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_f
     __ add(sp, sp, 32 * wordSize);
   }
 
-#ifdef _WINDOWS
+#ifdef R18_RESERVED
   /*
-  Do not modify r18_tls when restoring registers on Windows as it is used to
-  store the pointer to the current thread's TEB (where TLS variables are stored).
-  See r18_tls comment in register_aarch64.hpp.
+  Do not modify r18_tls when restoring registers if it is a reserved register. On Windows,
+  for example, r18_tls is used to store the pointer to the current thread's TEB (where TLS
+  variables are stored). Therefore, modifying r18_tls would corrupt the TEB pointer.
   */
   __ ldp(zr, r1, Address(__ post(sp, 2 * wordSize)));
   __ pop(RegSet::range(r2, r17), sp);


### PR DESCRIPTION
On Windows, r18_tls is used store the pointer to the current thread's TEB. Therefore, this register should never be modified (see details in [register_aarch64.hpp](https://github.com/openjdk/jdk25u/blob/jdk-25.0.1-ga/src/hotspot/cpu/aarch64/register_aarch64.hpp#L118-L128)). One scenario that results in the modification of r18_tls involves virtual threads. Frames are frozen by [Continuation::try_preempt](https://github.com/openjdk/jdk25u/blob/jdk-25.0.1-ga/src/hotspot/share/runtime/continuation.cpp#L159) on one carrier thread whose registers are saved. When the frame is thawed, execution can continue on a different carrier thread. When this happens, [rthread (x28) is fixed to point to the new carrier thread](https://github.com/openjdk/jdk25u/blob/jdk-25.0.1-ga/src/hotspot/share/runtime/continuationFreezeThaw.cpp#L2500-L2503). The continuation then results in [restore_live_registers](https://github.com/openjdk/jdk25u/blob/jdk-25.0.1-ga/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp#L313) restoring all the saved registers (including the fixed rthread register). However, this also restores x18, which was the TEB pointer for the previous carrier thread, causing the new carrier thread to execute with the TLS of the previous carrier thread. This causes hangs and occasional crashes in the virtual threads jtreg tests on Windows AArch64 that are resolved by this fix.