### PR TITLE
Revert "Do not modify r18_tls when restoring registers on Windows AArch64 (#19)"

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -310,18 +310,7 @@ static void restore_live_registers(StubAssembler* sasm, bool restore_fpu_registe
     __ add(sp, sp, 32 * wordSize);
   }
 
-#ifdef R18_RESERVED
-  /*
-  Do not modify r18_tls when restoring registers if it is a reserved register. On Windows,
-  for example, r18_tls is used to store the pointer to the current thread's TEB (where TLS
-  variables are stored). Therefore, modifying r18_tls would corrupt the TEB pointer.
-  */
-  __ pop(RegSet::range(r0, r17), sp);
-  __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
-  __ pop(RegSet::range(r20, r29), sp);
-#else
   __ pop(RegSet::range(r0, r29), sp);
-#endif
 }
 
 static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_fpu_registers = true)  {
@@ -334,20 +323,8 @@ static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_f
     __ add(sp, sp, 32 * wordSize);
   }
 
-#ifdef R18_RESERVED
-  /*
-  Do not modify r18_tls when restoring registers if it is a reserved register. On Windows,
-  for example, r18_tls is used to store the pointer to the current thread's TEB (where TLS
-  variables are stored). Therefore, modifying r18_tls would corrupt the TEB pointer.
-  */
-  __ ldp(zr, r1, Address(__ post(sp, 2 * wordSize)));
-  __ pop(RegSet::range(r2, r17), sp);
-  __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
-  __ pop(RegSet::range(r20, r29), sp);
-#else
   __ ldp(zr, r1, Address(__ post(sp, 16)));
   __ pop(RegSet::range(r2, r29), sp);
-#endif
 }
 
 


### PR DESCRIPTION
This reverts commit 9300fdae9386a3d872a1ab13e4eef65a69f63a38.

It was backported to jdk25u upstream in https://bugs.openjdk.org/browse/JDK-8374864 so we no longer need it in our patches.