### PR TITLE
Add critical fences on windows aarch64

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
@@ -51,6 +51,9 @@ import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import static jdk.internal.util.Architecture.*;
+import jdk.internal.util.OperatingSystem;
+
 /**
  * An unbounded {@link TransferQueue} based on linked nodes.
  * This queue orders elements FIFO (first-in-first-out) with respect
@@ -540,6 +543,14 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
     }
 
     /**
+     * True on platforms where CAS (release) + plain/volatile load
+     * to a different address does NOT provide StoreLoad ordering,
+     * requiring an explicit fence for Dekker-style patterns.
+     */
+    static final boolean NEEDS_STORELOAD_FENCE =
+        isAARCH64() && OperatingSystem.isWindows();
+
+    /**
      * The maximum number of estimated removal failures (sweepVotes)
      * to tolerate before sweeping through the queue unlinking
      * dead nodes that were initially pinned.  Must be a power of
@@ -590,6 +601,12 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
                 q = p.next;
                 if (p.isData != haveData && haveData != (m != null) &&
                     p.cmpExItem(m, e) == m) {
+                    // Full fence (StoreLoad) for Dekker with await() which
+                    // writes waiter then reads item. On ARM64, CAS
+                    // (ldaxr/stlxr) + plain load to a different field does
+                    // NOT provide StoreLoad ordering.
+                    if (NEEDS_STORELOAD_FENCE)
+                        VarHandle.fullFence();
                     Thread w = p.waiter;    // matched complementary node
                     if (p != h && h == cmpExHead(h, (q == null) ? p : q))
                         h.next = h;         // advance head; self-link old

--- a/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
@@ -177,6 +177,12 @@ public class SynchronousQueue<E> extends AbstractQueue<E>
                     else if (p.cmpExItem(m, e) != m)
                         p = head;                  // missed; restart
                     else {                         // matched complementary node
+                        // Full fence (StoreLoad) for Dekker with await() which
+                        // writes waiter then reads item. On ARM64, CAS
+                        // (ldaxr/stlxr) + plain load to a different field does
+                        // NOT provide StoreLoad ordering.
+                        if (NEEDS_STORELOAD_FENCE)
+                            VarHandle.fullFence();
                         Thread w = p.waiter;
                         cmpExHead(p, p.next);
                         LockSupport.unpark(w);

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -43,6 +43,9 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RejectedExecutionException;
 import jdk.internal.misc.Unsafe;
 
+import static jdk.internal.util.Architecture.*;
+import jdk.internal.util.OperatingSystem;
+
 /**
  * Provides a framework for implementing blocking locks and related
  * synchronizers (semaphores, events, etc) that rely on
@@ -464,6 +467,14 @@ public abstract class AbstractQueuedSynchronizer
     static final int CANCELLED = 0x80000000; // must be negative
     static final int COND      = 2;          // in a condition wait
 
+    /**
+     * True on platforms where CAS (release) + plain/volatile load
+     * to a different address does NOT provide StoreLoad ordering,
+     * requiring an explicit fence for Dekker-style patterns.
+     */
+    private static final boolean NEEDS_STORELOAD_FENCE =
+        isAARCH64() && OperatingSystem.isWindows();
+
     /** CLH Nodes */
     abstract static class Node {
         volatile Node prev;       // initially attached via casTail
@@ -782,6 +793,14 @@ public abstract class AbstractQueuedSynchronizer
                 Thread.onSpinWait();
             } else if (node.status == 0) {
                 node.status = WAITING;          // enable signal and recheck
+                // Full fence (StoreLoad) to ensure WAITING status is visible
+                // before re-reading state in tryAcquire/tryAcquireShared
+                // (Dekker pattern with releaseShared/release which writes
+                // state then reads node.status in signalNext).
+                // On ARM64, volatile write (stlr) + volatile read (ldar) to
+                // different addresses does NOT provide StoreLoad ordering.
+                if (NEEDS_STORELOAD_FENCE)
+                    U.fullFence();
             } else {
                 spins = postSpins = (byte)((postSpins << 1) | 1);
                 try {
@@ -1097,6 +1116,14 @@ public abstract class AbstractQueuedSynchronizer
      */
     public final boolean release(int arg) {
         if (tryRelease(arg)) {
+            // Full fence (StoreLoad) to ensure the state update from
+            // tryRelease is visible before reading node.status in signalNext
+            // (Dekker pattern: release writes state then reads status,
+            // acquire writes status then reads state).
+            // On ARM64, CAS (stlxr/release) + ldar to different addresses
+            // does NOT provide StoreLoad ordering.
+            if (NEEDS_STORELOAD_FENCE)
+                U.fullFence();
             signalNext(head);
             return true;
         }
@@ -1184,6 +1211,9 @@ public abstract class AbstractQueuedSynchronizer
      */
     public final boolean releaseShared(int arg) {
         if (tryReleaseShared(arg)) {
+            // Full fence (StoreLoad) — see comment in release()
+            if (NEEDS_STORELOAD_FENCE)
+                U.fullFence();
             signalNext(head);
             return true;
         }


### PR DESCRIPTION
ARM64 Dekker-pattern StoreLoad fences in java.util.concurrent
On ARM64, volatile write (STLR/release) + volatile read (LDAR/acquire) to
different addresses does NOT provide StoreLoad ordering. This breaks
Dekker-like protocols where one side writes field A then reads field B,
while the other writes B then reads A — both sides can miss each other's
stores.

This adds U.fullFence() / VarHandle.fullFence() at all identified
Dekker-pattern sites:

LinkedTransferQueue.java:
  - xfer(): between cmpExItem CAS and reading waiter (Dekker with
    await() which writes waiter then reads item)

SynchronousQueue.java:
  - xferLifo(): between cmpExItem CAS and reading waiter (same Dekker
    as LinkedTransferQueue)

AbstractQueuedSynchronizer.java:
  - acquire(): between node.status=WAITING and re-reading state in
    tryAcquire/tryAcquireShared (Dekker with release/releaseShared)
  - release(): between tryRelease state update and reading node.status
    in signalNext
  - releaseShared(): same as release()

These fences are correctness-critical on ARM64, functionally redundant
on x86 (TSO already provides StoreLoad), and appear only on non-hot
paths (state transitions, not tight loops).

Finally the fences are only added on Windows ARM64 in this patch