### PR TITLE
Remove exception code checks from handle_safefetch

### DIFF
--- a/src/hotspot/os/windows/safefetch_static_windows.cpp
+++ b/src/hotspot/os/windows/safefetch_static_windows.cpp
@@ -46,8 +46,7 @@ extern "C" char _SafeFetchN_fault[];
 
 bool handle_safefetch(int exception_code, address pc, void* context) {
   CONTEXT* ctx = (CONTEXT*)context;
-  if ((exception_code == EXCEPTION_ACCESS_VIOLATION ||
-       exception_code == EXCEPTION_GUARD_PAGE) && ctx != nullptr) {
+  if (ctx != nullptr) {
     if (pc == (address)_SafeFetch32_fault) {
       os::win32::context_set_pc(ctx, (address)_SafeFetch32_continuation);
       return true;


### PR DESCRIPTION
As @mo-beck pointed out, handle_safefetch does not need to check the exception code given that it already detects that the PC is from the safe fetch LDR instruction. Removing exception code checking will prevent having to update the exception code list in future. This is a follow-up to [JDK-8383541: Safefetch should return the error value when accessing pages protected with PAGE_GUARD on windows-aarch64](https://bugs.openjdk.org/browse/JDK-8383541)

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
