### PR TITLE
Enable the ReservedStackTests on windows-aarch64

### DIFF
--- a/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTest.java
+++ b/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTest.java
@@ -241,6 +241,7 @@ public class ReservedStackTest {
             (Platform.isLinux() &&
              (Platform.isPPC() || Platform.isS390x() || Platform.isX64() ||
               Platform.isX86() || Platform.isAArch64() || Platform.isRISCV64())) ||
+            (Platform.isWindows() && Platform.isAArch64()) ||
             Platform.isOSX();
     }
 


### PR DESCRIPTION
[JEP 270](https://openjdk.org/jeps/270) introduced reservation of extra space on thread stacks for use by critical sections, so that they can complete their execution where regular code would have been interrupted by a stack overflow. The ReservedStackTest uses the `-XX:StackReservedPages=1` flag to test this functionality. This flag can be used on platforms on which SUPPORT_RESERVED_STACK_AREA is defined. Otherwise, a warning is displayed by [Arguments::check_vm_args_consistency()](https://github.com/openjdk/jdk/blob/a37b02baa220b4434b1fb59f123fd3f5ce97aab0/src/hotspot/share/runtime/arguments.cpp#L1597-L1602)

SUPPORT_RESERVED_STACK_AREA is defined on macos-aarch64, linux-aarch64, and windows-aarch64 platforms in [globalDefinitions_aarch64](https://github.com/openjdk/jdk/blob/a37b02baa220b4434b1fb59f123fd3f5ce97aab0/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp#L64). Therefore, the warning is not displayed on any of these platforms. However, ReservedStackTest fails on windows-aarch64 because it isn't listed as a supported platform in the test. This PR registers windows-aarch64 as an always supported platform for this stack reservation feature. The test now passes on windows-aarch64 with this change.

---------
- [ X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
