### PR TITLE
Constrain G1 interval to be a multiple of `interval_gran`

### DIFF
--- a/ms-patches/g1-interval-constraint.yml
+++ b/ms-patches/g1-interval-constraint.yml
@@ -1,0 +1,8 @@
+title: Constrain G1 interval to be a multiple of `interval_gran`
+- work_item: 3013486
+- jbs_bug:
+- author: raneashay
+- owner: raneashay
+- contributors: raneashay
+- details:
+- release_note: Constrain G1 interval to be a multiple of `interval_gran` (10ms)

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -350,7 +350,8 @@
   product(uintx, G1TimeBasedEvaluationIntervalMillis, 60000, MANAGEABLE,    \
           "Interval in milliseconds between periodic heap-size evaluations "\
           "when G1UseTimeBasedHeapSizing is enabled")                       \
-          range(1000, LP64_ONLY(max_jlong) NOT_LP64(max_uintx / 2))         \
+          range(1000, max_jint / 10 * 10)                                   \
+          constraint(G1TimeBasedEvaluationIntervalMillisConstraintFunc,AtParse) \
                                                                             \
   product(uintx, G1UncommitDelayMillis, 300000, MANAGEABLE,                 \
           "A region is considered inactive if it has not been accessed "    \

--- a/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
+++ b/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 #include "gc/shared/bufferNode.hpp"
 #include "gc/shared/ptrQueue.hpp"
 #include "runtime/globals_extension.hpp"
+#include "runtime/task.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 JVMFlag::Error G1RemSetArrayOfCardsEntriesConstraintFunc(uint value, bool verbose) {
@@ -117,6 +118,19 @@ JVMFlag::Error G1MaxNewSizePercentConstraintFunc(uint value, bool verbose) {
   } else {
     return JVMFlag::SUCCESS;
   }
+}
+
+JVMFlag::Error G1TimeBasedEvaluationIntervalMillisConstraintFunc(uintx value, bool verbose) {
+  if (!UseG1GC) return JVMFlag::SUCCESS;
+
+  if ((value % PeriodicTask::interval_gran) != 0) {
+    JVMFlag::printError(verbose,
+                        "G1TimeBasedEvaluationIntervalMillis (%zu) must be "
+                        "evenly divisible by PeriodicTask::interval_gran (%d)\n",
+                        value, PeriodicTask::interval_gran);
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+  return JVMFlag::SUCCESS;
 }
 
 JVMFlag::Error MaxGCPauseMillisConstraintFuncG1(uintx value, bool verbose) {

--- a/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.hpp
+++ b/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@
   f(size_t, G1HeapRegionSizeConstraintFunc)           \
   f(uint,  G1NewSizePercentConstraintFunc)           \
   f(uint,  G1MaxNewSizePercentConstraintFunc)        \
+  f(uintx, G1TimeBasedEvaluationIntervalMillisConstraintFunc) \
                                                       \
   /* G1 Subconstraints */                             \
   f(uintx,  MaxGCPauseMillisConstraintFuncG1)         \


### PR DESCRIPTION
Without this patch, TestOptionsWithRanges.java fails with a JVM crash.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
