### PR TITLE
Add MSys2 support for specific tests

### DIFF
--- a/ms-patches/msys2-fixes-1.yml
+++ b/ms-patches/msys2-fixes-1.yml
@@ -1,0 +1,8 @@
+title: Add support for MSys2 in test framework
+- work_item: 3013436
+- jbs_bug:
+- author: raneashay
+- owner: raneashay
+- contributors: raneashay
+- details:
+- release_note: Add missing support for MSys2 in test framework

--- a/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
+++ b/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
@@ -58,6 +58,11 @@ case "$OS" in
     FS="\\"
     isCygwin=true
     ;;
+  MSYS* | MINGW*)
+    PS=";"
+    OS="Windows"
+    FS="\\"
+    ;;
   * )
     echo "Unrecognized system!"
     exit 1;

--- a/test/jdk/javax/script/CommonSetup.sh
+++ b/test/jdk/javax/script/CommonSetup.sh
@@ -51,6 +51,11 @@ case "$OS" in
     FS="\\"
     isCygwin=true
     ;;
+  MSYS* | MINGW* )
+    PS=";"
+    OS="Windows"
+    FS="\\"
+    ;;
   * )
     echo "Unrecognized system!"
     exit 1;

--- a/test/jdk/tools/launcher/ClassPathWildCard.sh
+++ b/test/jdk/tools/launcher/ClassPathWildCard.sh
@@ -149,7 +149,7 @@ CreateClassFiles D
 
 OS=`uname -s`
 case $OS in 
-    Windows*|CYGWIN*)
+    Windows*|CYGWIN*|MSYS*|MINGW*)
         PATHSEP=";"
         ExecJava "" "${PATHSEP}NOOPDIR"
         ExecJava "w" "${PATHSEP}NOOPDIR"


### PR DESCRIPTION
See PR 31204 in JDK tip for details.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
