### PR TITLE
Add support for MSys2 in remaining tests

### DIFF
--- a/ms-patches/msys2-fixes-2.yml
+++ b/ms-patches/msys2-fixes-2.yml
@@ -1,0 +1,8 @@
+title: Fix MSys2 support in test framework for remaining tests
+- work_item: 3013436
+- jbs_bug:
+- author: raneashay
+- owner: raneashay
+- contributors: raneashay
+- details:
+- release_note: Add support for MSys2 in remaining tests in test framework

--- a/test/jdk/java/awt/GraphicsEnvironment/TestDetectHeadless/TestDetectHeadless.sh
+++ b/test/jdk/java/awt/GraphicsEnvironment/TestDetectHeadless/TestDetectHeadless.sh
@@ -36,7 +36,7 @@
 
 OS=`uname -s`
 case "$OS" in
-    Windows* | CYGWIN* | Darwin)
+    Windows* | CYGWIN* | MSYS* | MINGW* | Darwin)
         echo "Passed"; exit 0 ;;
     * ) unset DISPLAY ;;
 esac

--- a/test/jdk/java/awt/JAWT/JAWT.sh
+++ b/test/jdk/java/awt/JAWT/JAWT.sh
@@ -83,7 +83,7 @@ case "$OS" in
     fi
 	SYST="windows"
     ;;
-  CYGWIN* )
+  CYGWIN* | MSYS* | MINGW* )
     NULL=/dev/null
     PS=":"
     FS="/"

--- a/test/jdk/java/awt/Toolkit/AutoShutdown/EventQueuePush/EventQueuePushAutoshutdown.sh
+++ b/test/jdk/java/awt/Toolkit/AutoShutdown/EventQueuePush/EventQueuePushAutoshutdown.sh
@@ -60,7 +60,7 @@ pass()
 # The beginning of the script proper
 OS=`uname -s`
 case "$OS" in
-   AIX | CYGWIN* | Darwin | Linux )
+   AIX | CYGWIN* | MSYS* | MINGW* | Darwin | Linux )
       FILESEP="/"
       ;;
 

--- a/test/jdk/java/awt/Toolkit/AutoShutdown/ShowExitTest/ShowExitTest.sh
+++ b/test/jdk/java/awt/Toolkit/AutoShutdown/ShowExitTest/ShowExitTest.sh
@@ -87,7 +87,7 @@ case "$OS" in
       TMP=`cd "${SystemRoot}/Temp"; echo ${PWD}`
       ;;
 
-    CYGWIN* )
+    CYGWIN* | MSYS* | MINGW* )
       VAR="A different value for Cygwin"
       DEFAULT_JDK="/cygdrive/c/Program\ Files/Java/jdk1.8.0"
       FILESEP="/"

--- a/test/jdk/java/awt/Toolkit/BadDisplayTest/BadDisplayTest.sh
+++ b/test/jdk/java/awt/Toolkit/BadDisplayTest/BadDisplayTest.sh
@@ -23,7 +23,7 @@ ${TESTJAVA}/bin/javac -cp ${TESTSRC} -d . ${TESTSRC}/BadDisplayTest.java
 
 OS=`uname -s`
 case "$OS" in
-    Windows* | CYGWIN* | Darwin)
+    Windows* | CYGWIN* | MSYS* | MINGW* | Darwin)
         echo "Passed"; exit 0 ;;
 esac
 

--- a/test/jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh
+++ b/test/jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh
@@ -66,7 +66,7 @@ echo "Creating manifest file..."
 
 OS=`uname -s`
 case ${OS} in
-    CYGWIN*)
+    CYGWIN* | MSYS* | MINGW*)
         CYGWIN="CYGWIN"
         ;;
     *)

--- a/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
+++ b/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
@@ -52,7 +52,7 @@ case "$OS" in
     OS="Windows"
     FS="\\"
     ;;
-  CYGWIN*)
+  CYGWIN* | MSYS* | MINGW*)
     PS=";"
     OS="Windows"
     FS="\\"

--- a/test/jdk/javax/imageio/metadata/IIOMetadataFormat/runMetadataFormatTest.sh
+++ b/test/jdk/javax/imageio/metadata/IIOMetadataFormat/runMetadataFormatTest.sh
@@ -96,7 +96,7 @@ case "$OS" in
       FILESEP="\\"
       ;;
 
-    CYGWIN* )
+    CYGWIN* | MSYS* | MINGW* )
       VAR="A different value for CYGWIN"
       DEFAULT_JDK=/none
       FILESEP="/"

--- a/test/jdk/javax/imageio/metadata/IIOMetadataFormat/runMetadataFormatThreadTest.sh
+++ b/test/jdk/javax/imageio/metadata/IIOMetadataFormat/runMetadataFormatThreadTest.sh
@@ -97,7 +97,7 @@ case "$OS" in
       FILESEP="\\"
       ;;
     
-    CYGWIN* )
+    CYGWIN* | MSYS* | MINGW* )
       VAR="A different value for CYGWIN"
       DEFAULT_JDK=/none
       FILESEP="/"

--- a/test/jdk/javax/imageio/plugins/external_plugin_tests/TestClassPathPlugin.sh
+++ b/test/jdk/javax/imageio/plugins/external_plugin_tests/TestClassPathPlugin.sh
@@ -60,7 +60,7 @@ $JAR cf $PLUGINDIR/simp.jar -C $TESTCLASSES/tmpdir META-INF/services \
 
 OS=`uname -s`
 case "$OS" in
-  Windows_* | CYGWIN* )
+  Windows_* | CYGWIN* | MSYS* | MINGW* )
 CPSEP=";"
   ;;
   * )

--- a/test/jdk/javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh
+++ b/test/jdk/javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh
@@ -115,7 +115,7 @@ case "$OS" in
       TMP=`cd "${SystemRoot}/Temp"; echo ${PWD}`
       ;;
 
-   CYGWIN* )
+   CYGWIN* | MSYS* | MINGW* )
       FILESEP="/"
       PATHSEP=";"
       TMP="/tmp"
@@ -243,7 +243,7 @@ echo
 
 
 case "$OS" in
-   CYGWIN* )
+   CYGWIN* | MSYS* | MINGW* )
       TEST_CODEBASE=$(cygpath -m ${PWD})
       TEST_PLUGIN_JAR=$(cygpath -m ${PLUGINDST_DIR}${FILESEP}${TEST_PLUGIN})
       ;;

--- a/test/jdk/javax/script/CommonSetup.sh
+++ b/test/jdk/javax/script/CommonSetup.sh
@@ -45,7 +45,7 @@ case "$OS" in
     OS="Windows"
     FS="\\"
     ;;
-  CYGWIN* )
+  CYGWIN* | MSYS* | MINGW* )
     PS=";"
     OS="Windows"
     FS="\\"

--- a/test/jdk/sun/jvmstat/testlibrary/utils.sh
+++ b/test/jdk/sun/jvmstat/testlibrary/utils.sh
@@ -40,7 +40,7 @@ setup() {
 
     OS=`uname -s`
     case ${OS} in
-    Windows_* | CYGWIN*)
+    Windows_* | CYGWIN* | MSYS* | MINGW*)
         PS=";"
         FS="\\"
         ;;
@@ -54,7 +54,7 @@ setup() {
 verify_os() {
     OS=`uname -s`
     case ${OS} in
-    Windows_95 | Windows_98 | Windows_ME | CYGWIN* )
+    Windows_95 | Windows_98 | Windows_ME | CYGWIN* | MSYS* | MINGW* )
         echo "Test bypassed: jvmstat feature not supported on ${OS}"
         exit 0
         ;;

--- a/test/jdk/tools/launcher/MultipleJRE.sh
+++ b/test/jdk/tools/launcher/MultipleJRE.sh
@@ -63,7 +63,7 @@ OS=`uname -s`;
 #
 IsWindows() {
     case "$OS" in
-        Windows* | CYGWIN* )
+        Windows* | CYGWIN* | MSYS* | MINGW* )
             printf "true"
 	;;
 	* )


### PR DESCRIPTION
See PR 31261 in JDK tip for details.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
