### PR TITLE
Selectively enable NTLM tests to run only on supported platforms

### DIFF
--- a/ms-patches/ntlm-tests.yml
+++ b/ms-patches/ntlm-tests.yml
@@ -1,0 +1,8 @@
+title: Fix NTLM tests
+- work_item: 3013445
+- jbs_bug:
+- author: raneashay
+- owner: raneashay
+- contributors: raneashay
+- details:
+- release_note: Selectively enable NTLM tests on only the supported platforms

--- a/test/jdk/sun/net/www/protocol/http/NTLMHeadTest.java
+++ b/test/jdk/sun/net/www/protocol/http/NTLMHeadTest.java
@@ -22,8 +22,9 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @bug 8270290
+ * @requires os.family != "windows"
  * @library /test/lib
  * @run main/othervm NTLMHeadTest SERVER
  * @run main/othervm NTLMHeadTest PROXY
@@ -47,6 +48,18 @@
  *      NTLMSSP_CHALLENGE response includes Content-Length, but does not
  *      include the body.
  */
+
+/*
+ * @test id=windows
+ * @bug 8270290
+ * @comment Only run on specific Windows OS versions because NTLMv1 is no longer supported starting Windows 11 and Windows Server 2025
+ * @requires os.family == "windows" & (os.name == "Windows 10" | os.name == "Windows Server 2016" | os.name == "Windows Server 2019" | os.name == "Windows Server 2022")
+ * @library /test/lib
+ * @run main/othervm NTLMHeadTest SERVER
+ * @run main/othervm NTLMHeadTest PROXY
+ * @run main/othervm NTLMHeadTest TUNNEL
+ */
+
 
 import java.net.*;
 import java.io.*;

--- a/test/jdk/sun/net/www/protocol/http/TestTransparentNTLM.java
+++ b/test/jdk/sun/net/www/protocol/http/TestTransparentNTLM.java
@@ -26,8 +26,9 @@
  * @bug 8225425
  * @summary Verifies that transparent NTLM (on Windows) is not used by default,
  *          and is used only when the relevant property is set.
- * @requires os.family == "windows"
  * @library /test/lib
+ * @comment Only run on specific Windows OS versions because NTLMv1 is no longer supported starting Windows 11 and Windows Server 2025
+ * @requires os.family == "windows" & (os.name == "Windows 10" | os.name == "Windows Server 2016" | os.name == "Windows Server 2019" | os.name == "Windows Server 2022")
  * @run testng/othervm
  *      -Dtest.auth.succeed=false
  *      TestTransparentNTLM


### PR DESCRIPTION
See PR 31141 in JDK tip for details.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
