### PR TITLE
Disable reserved stack areas for critical sections on Windows AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -63,7 +63,9 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 // evidence that it's worth doing.
 #define DEOPTIMIZE_WHEN_PATCHING
 
+#if !defined(_WINDOWS)
 #define SUPPORT_RESERVED_STACK_AREA
+#endif
 
 #if defined(__APPLE__) || defined(_WIN64)
 #define R18_RESERVED

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -48,7 +48,7 @@ define_pd_global(intx, OptoLoopAlignment,        16);
 // stack if compiled for unix and LP64. To pass stack overflow tests we need
 // 20 shadow pages.
 #define DEFAULT_STACK_SHADOW_PAGES (20 DEBUG_ONLY(+5))
-#define DEFAULT_STACK_RESERVED_PAGES (1)
+#define DEFAULT_STACK_RESERVED_PAGES (NOT_WINDOWS(1) WINDOWS_ONLY(0))
 
 #define MIN_STACK_YELLOW_PAGES DEFAULT_STACK_YELLOW_PAGES
 #define MIN_STACK_RED_PAGES    DEFAULT_STACK_RED_PAGES


### PR DESCRIPTION
[JEP 270](https://openjdk.org/jeps/270) introduced reservation of extra space on thread stacks for use by critical sections, so that they can complete their execution where regular code would have been interrupted by a stack overflow. The ReservedStackTest uses the `-XX:StackReservedPages=1` flag to test this functionality. This flag can be used on platforms on which SUPPORT_RESERVED_STACK_AREA is defined. Otherwise, a warning is displayed by [Arguments::check_vm_args_consistency()](https://github.com/openjdk/jdk/blob/a37b02baa220b4434b1fb59f123fd3f5ce97aab0/src/hotspot/share/runtime/arguments.cpp#L1597-L1602)

SUPPORT_RESERVED_STACK_AREA is currently defined for all aarch64 platforms in [globalDefinitions_aarch64](https://github.com/openjdk/jdk/blob/a37b02baa220b4434b1fb59f123fd3f5ce97aab0/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp#L64). Therefore, the warning is not displayed on any of these platforms. However, ReservedStackTest fails on windows-aarch64 because it isn't a supported platform. This PR prevents SUPPORT_RESERVED_STACK_AREA from being defined on windows-aarch64, thereby enabling the test to pass on this platform.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
